### PR TITLE
Fix box surface invisible and container too dark issues

### DIFF
--- a/js/viewer/BoxViewer.js
+++ b/js/viewer/BoxViewer.js
@@ -18,8 +18,7 @@ export class BoxViewer {
         this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type    = THREE.PCFSoftShadowMap;
-        this.renderer.physicallyCorrectLights = true;
-        this.renderer.outputEncoding = THREE.sRGBEncoding;
+        // physicallyCorrectLights / outputEncoding omitted: incompatible with Three.js r81
 
         this.scene = new THREE.Scene();
         this.scene.background = new THREE.Color(0xf0f2f5);
@@ -39,9 +38,9 @@ export class BoxViewer {
     }
 
     _setupLights() {
-        this.scene.add(new THREE.AmbientLight(0xfff4e0, 0.55));
+        this.scene.add(new THREE.AmbientLight(0xfff4e0, 0.75));
 
-        const key = new THREE.DirectionalLight(0xfffaf0, 0.90);
+        const key = new THREE.DirectionalLight(0xfffaf0, 1.10);
         key.position.set(400, 600, 500);
         key.castShadow = true;
         key.shadow.mapSize.width  = 2048;

--- a/js/viewer/RenderableBox.js
+++ b/js/viewer/RenderableBox.js
@@ -27,12 +27,18 @@ export class RenderableBox extends Box {
         const TILE = 40; // cm per texture tile
         const baseTex = TextureFactory.getCardboardTexture();
 
-        // BoxGeometry face order: +X, -X, +Y, -Y, +Z, -Z
-        const rW = width / TILE, rH = height / TILE, rD = depth / TILE;
-        const mkMat = (rx, ry) => new THREE.MeshStandardMaterial({
-            map:                 cloneTex(baseTex, rx, ry),
-            color:               finalColor,
-            opacity:             options.fragile ? 0.80 : 1.0,
+        // Use white color so the cardboard texture shows its natural warm brown.
+        // Group identity is conveyed via a subtle emissive tint + colored edge lines.
+        // (Multiplying the group color directly onto the texture would produce near-black.)
+        const emissiveColor = new THREE.Color(finalColor).multiplyScalar(0.22);
+        const tex = cloneTex(baseTex,
+            Math.max(1, (width + depth) * 0.5 / TILE),
+            Math.max(1, height / TILE));
+        const material = new THREE.MeshStandardMaterial({
+            map:                 tex,
+            color:               0xffffff,      // white → texture shows naturally
+            emissive:            emissiveColor, // soft group-color glow
+            opacity:             options.fragile ? 0.78 : 1.0,
             metalness:           0.0,
             roughness:           0.82,
             transparent:         !!options.fragile,
@@ -41,19 +47,14 @@ export class RenderableBox extends Box {
             polygonOffsetUnits:  1
         });
 
-        const materials = [
-            mkMat(rD, rH), mkMat(rD, rH),  // ±X
-            mkMat(rW, rD), mkMat(rW, rD),  // ±Y
-            mkMat(rW, rH), mkMat(rW, rH),  // ±Z
-        ];
-
         const geometry = new THREE.BoxGeometry(1, 1, 1);
-        this.mesh = new THREE.Mesh(geometry, materials);
+        this.mesh = new THREE.Mesh(geometry, material);
         this.mesh.castShadow    = true;
         this.mesh.receiveShadow = true;
         this.mesh.visible       = false;
 
-        const edgeMat = new THREE.LineBasicMaterial({ color: 0x2a1a0a, opacity: 0.55, transparent: true });
+        // Edge lines use group color — primary visual identifier for each box group
+        const edgeMat = new THREE.LineBasicMaterial({ color: finalColor, opacity: 0.85, transparent: true });
         this.edges = new THREE.LineSegments(new THREE.EdgesGeometry(geometry), edgeMat);
         this.mesh.add(this.edges);
 
@@ -86,7 +87,8 @@ export class RenderableBox extends Box {
     removeFromScene() {
         if (!this.viewer || !this.mesh) return;
         this.viewer.scene.remove(this.mesh);
-        const mats = Array.isArray(this.mesh.material) ? this.mesh.material : [this.mesh.material];
-        mats.forEach(m => { if (m.map) m.map.dispose(); m.dispose(); });
+        const m = this.mesh.material;
+        if (m && m.map) m.map.dispose();
+        if (m) m.dispose();
     }
 }

--- a/js/viewer/RenderableContainer.js
+++ b/js/viewer/RenderableContainer.js
@@ -133,10 +133,11 @@ export class RenderableContainer extends Container {
         floor.receiveShadow = true;
         group.add(floor);
 
+        // Very low opacity so interior is clearly visible through the walls
         const mkWall = (rx, ry) => new THREE.MeshStandardMaterial({
             map: cloneTex(baseTex, rx, ry),
-            color: 0x4a7055, roughness: 0.65, metalness: 0.40,
-            transparent: true, opacity: 0.38, side: THREE.DoubleSide, depthWrite: false
+            color: 0xffffff, roughness: 0.65, metalness: 0.40,
+            transparent: true, opacity: 0.15, side: THREE.DoubleSide, depthWrite: false
         });
 
         const addWall = (geo, mat, pos, rotY = 0) => {


### PR DESCRIPTION
Root cause: Three.js r81 — material color multiplied with texture, so group colors (e.g. blue #4e79a7) × brown cardboard = near-black.

Fixes:
- Boxes: color=0xffffff so cardboard texture shows naturally (warm brown), emissive tint conveys group identity, edge lines colored with group color as primary visual identifier
- Container walls: opacity 0.15 (was 0.38) + color=0xffffff so interior is clearly visible through barely-there walls
- Remove physicallyCorrectLights/outputEncoding (r81 compat), bump ambient/key light intensity to compensate

https://claude.ai/code/session_01BNfbxHiaP4B3VAetqr8ZwZ