### PR TITLE
Update viewer styling and improve rendering performance

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -320,7 +320,8 @@ body {
     flex: 1;
     min-height: 0;
     position: relative;
-    background: #f8f9fa;
+    background: #ffffff;
+    box-shadow: inset 0 0 40px rgba(0,0,0,0.06);
 }
 
 #canvas {

--- a/js/viewer/BoxViewer.js
+++ b/js/viewer/BoxViewer.js
@@ -13,7 +13,7 @@ export class BoxViewer {
         this.canvas = canvas;
 
         this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
-        this.renderer.setClearColor(0xf0f2f5);
+        this.renderer.setClearColor(0xffffff);
         this.renderer.setPixelRatio(window.devicePixelRatio);
         this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
         this.renderer.shadowMap.enabled = true;
@@ -21,7 +21,7 @@ export class BoxViewer {
         // physicallyCorrectLights / outputEncoding omitted: incompatible with Three.js r81
 
         this.scene = new THREE.Scene();
-        this.scene.background = new THREE.Color(0xf0f2f5);
+        this.scene.background = new THREE.Color(0xffffff);
 
         this.camera = new THREE.PerspectiveCamera(50, canvas.clientWidth / canvas.clientHeight);
         this.camera.position.set(200, 200, 300);

--- a/js/viewer/RenderableBox.js
+++ b/js/viewer/RenderableBox.js
@@ -47,7 +47,7 @@ export class RenderableBox extends Box {
             polygonOffsetUnits:  1
         });
 
-        const geometry = new THREE.BoxGeometry(1, 1, 1);
+        const geometry = new THREE.BoxBufferGeometry(1, 1, 1);
         this.mesh = new THREE.Mesh(geometry, material);
         this.mesh.castShadow    = true;
         this.mesh.receiveShadow = true;


### PR DESCRIPTION
This PR updates the 3D box viewer styling and improves rendering performance through several targeted changes.

**Key changes:**

- **Background color updates**: Changed renderer and scene background from light gray (#f0f2f5) to white (#ffffff) for a cleaner appearance
- **Canvas styling**: Updated canvas container background to white (#ffffff) and added a subtle inset shadow (0 0 40px rgba(0,0,0,0.06)) for visual depth
- **Rendering optimization**: Replaced `THREE.BoxGeometry` with `THREE.BoxBufferGeometry` in RenderableBox for improved memory efficiency and rendering performance

**Implementation details:**

The background color changes are applied consistently across three layers: the WebGL renderer clear color, the Three.js scene background, and the CSS canvas container. The addition of the inset box-shadow provides subtle visual separation without affecting the overall brightness of the interface.

The geometry optimization uses BufferGeometry, which stores vertex data more efficiently in GPU memory, resulting in better performance for rendering the 3D box mesh.

https://claude.ai/code/session_01EKCtPwHSs8FAh5W3FaEtDi