### PR TITLE
Fix corrugated geometry crash and camera clipping

### DIFF
--- a/js/viewer/BoxViewer.js
+++ b/js/viewer/BoxViewer.js
@@ -25,7 +25,7 @@ export class BoxViewer {
         // Subtle exponential fog gives depth without obscuring boxes
         this.scene.fog = new THREE.FogExp2(0xdde2e8, 0.0006);
 
-        this.camera = new THREE.PerspectiveCamera(50, canvas.clientWidth / canvas.clientHeight);
+        this.camera = new THREE.PerspectiveCamera(50, canvas.clientWidth / canvas.clientHeight, 0.5, 8000);
         this.camera.position.set(200, 200, 300);
 
         this.controls = new OrbitControls(this.camera, this.renderer.domElement);

--- a/js/viewer/RenderableContainer.js
+++ b/js/viewer/RenderableContainer.js
@@ -29,7 +29,8 @@ function makeCorrugatedGeo(width, height, ridgeW, amp) {
     const numRidges  = Math.max(4, Math.round(width / ridgeW));
     const segsX      = numRidges * 8;   // 8 verts per ridge → smooth sine
     const segsY      = Math.max(2, Math.round(height / ridgeW));
-    const geo        = new THREE.PlaneGeometry(width, height, segsX, segsY);
+    // Must use PlaneBufferGeometry (not PlaneGeometry) in r81 to get BufferAttribute API
+    const geo        = new THREE.PlaneBufferGeometry(width, height, segsX, segsY);
     const pos        = geo.attributes.position;
 
     for (let i = 0; i < pos.count; i++) {


### PR DESCRIPTION
- Use PlaneBufferGeometry instead of PlaneGeometry in makeCorrugatedGeo: Three.js r81's PlaneGeometry is the legacy Geometry class (no attributes.position); PlaneBufferGeometry is the BufferGeometry variant that exposes the BufferAttribute API required for vertex displacement
- Set PerspectiveCamera near=0.5 far=8000 to prevent objects being clipped when zooming in or when the white ground plane is in view

https://claude.ai/code/session_01SMCTQdzswG62y2umjUe89i