### PR TITLE
Fix camera ground clipping and improve mobile 3D view size

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -672,7 +672,7 @@ select.form-control {
 @media (max-width: 768px) {
     #app-body   { flex-direction: column; height: auto; overflow: visible; }
     #sidebar    { width: 100% !important; max-width: 100% !important; border-right: none; border-bottom: 1px solid var(--border); }
-    #main-area  { height: 80vw; min-height: 300px; }
+    #main-area  { height: 60vh; min-height: 400px; }
     #canvas-wrapper { flex: 1; }
     #sidebar-resize-handle { display: none; }
 }

--- a/js/viewer/BoxViewer.js
+++ b/js/viewer/BoxViewer.js
@@ -29,9 +29,10 @@ export class BoxViewer {
         this.camera.position.set(200, 200, 300);
 
         this.controls = new OrbitControls(this.camera, this.renderer.domElement);
-        this.controls.enableDamping = true;
-        this.controls.dampingFactor = 0.5;
-        this.controls.enableZoom   = true;
+        this.controls.enableDamping  = true;
+        this.controls.dampingFactor  = 0.5;
+        this.controls.enableZoom     = true;
+        this.controls.maxPolarAngle  = Math.PI / 2; // prevent camera going below ground
 
         this._setupLights();
         this._addGroundPlane();


### PR DESCRIPTION
- Add maxPolarAngle = Math.PI/2 to OrbitControls so the camera cannot
  orbit below the ground plane (y = 0)
- Change mobile #main-area from 80vw/300px to 60vh/400px so the 3D
  canvas is taller and more usable on portrait phone screens

https://claude.ai/code/session_01Q5DQHRyxCppojrysTk5WTA