### PR TITLE
fix: improve container rendering and add step-by-step packing controls

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -492,6 +492,68 @@ select.form-control {
 
 #canvas { width: 100%; height: 100%; display: block; }
 
+/* ── Step playback controls ──────────────── */
+#step-controls {
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+    border-top: 1px solid var(--border);
+    background: var(--bg-header-field);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+}
+.step-btn {
+    min-width: 32px;
+    height: 28px;
+    padding: 0 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-card);
+    color: var(--text-main);
+    font-size: 0.80rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.step-btn:hover:not(:disabled) { background: var(--accent-light, #e8f0fe); }
+.step-btn:disabled { opacity: 0.38; cursor: default; }
+.step-btn.step-play {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+    font-size: 0.85rem;
+    min-width: 38px;
+}
+.step-btn.step-play:hover:not(:disabled) { filter: brightness(1.1); }
+.step-slider {
+    flex: 1;
+    min-width: 60px;
+    height: 4px;
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+.step-label {
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    min-width: 44px;
+    text-align: center;
+}
+.step-speed-wrap {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 4px;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+}
+.step-speed {
+    width: 64px;
+    height: 4px;
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+#speed-label { white-space: nowrap; min-width: 34px; }
+
 /* ── Stats bar ────────────────────────────── */
 #stats-bar {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -256,6 +256,23 @@
                         </div>
                     </div>
                 </div>
+                <!-- Step-by-step playback controls (shown after solve) -->
+                <div id="step-controls" style="display:none;">
+                    <button class="step-btn" id="btn-step-first" onclick="stepFirst()" title="第一步">⏮</button>
+                    <button class="step-btn" id="btn-step-prev"  onclick="stepPrev()"  title="上一步">◀</button>
+                    <button class="step-btn step-play" id="btn-step-play" onclick="togglePlay()" title="播放/暂停">▶</button>
+                    <button class="step-btn" id="btn-step-next"  onclick="stepNext()"  title="下一步">▶|</button>
+                    <button class="step-btn" id="btn-step-last"  onclick="stepLast()"  title="最后一步">⏭</button>
+                    <input  class="step-slider" id="step-slider" type="range" min="0" max="0" value="0"
+                            oninput="onStepSlider(this.value)">
+                    <span class="step-label" id="step-label">0 / 0</span>
+                    <span class="step-speed-wrap" title="播放间隔">
+                        <input class="step-speed" id="speed-slider" type="range" min="100" max="2000" value="600" step="100"
+                               oninput="onSpeedChange(this.value)">
+                        <span id="speed-label">600ms</span>
+                    </span>
+                </div>
+
                 <div id="stats-bar">
                     <div class="stat-item">
                         <span class="stat-label">装箱率</span>

--- a/js/main.js
+++ b/js/main.js
@@ -31,6 +31,12 @@ let currentContainerType = 'container';
 let selectedAlgo = 'heuristic';
 let panelManager, statsDisplay, boxTable;
 
+// ─── Step playback state ──────────────────────────────────────────────────────
+let _packedBoxes   = [];   // result of last solve
+let _currentStep   = 0;   // how many boxes are currently visible
+let _playTimer     = null; // interval handle when playing
+let _playInterval  = 600; // ms between steps during auto-play
+
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 window.addEventListener('DOMContentLoaded', () => {
     _initViewer();
@@ -254,13 +260,13 @@ function _solveInternal() {
     const SolverClass = solverMap[selectedAlgo] || HeuristicSolver;
     const unpacked    = new SolverClass(container, appBoxes).solve();
 
-    // Animate boxes appearing one-by-one
-    const packed = container.boxes;
-    let i = 0;
-    (function step() {
-        if (i < packed.length) { packed[i++].visible = true; setTimeout(step, 80); }
-    })();
+    // Store packed result and reset step state
+    _packedBoxes = container.boxes.slice();
+    _stopPlay();
+    _currentStep = 0;
+    _packedBoxes.forEach(b => { b.visible = false; });
 
+    _updateStepControls();
     statsDisplay.update(container.getStats(), appBoxes.length);
 
     if (unpacked.length > 0) {
@@ -270,3 +276,73 @@ function _solveInternal() {
             `${unpacked.length} 个箱子无法放入容器`;
     }
 }
+
+// ─── Step control helpers ─────────────────────────────────────────────────────
+function _applyStep(n) {
+    const total = _packedBoxes.length;
+    n = Math.max(0, Math.min(total, n));
+    for (let i = 0; i < total; i++) {
+        _packedBoxes[i].visible = i < n;
+    }
+    _currentStep = n;
+    _updateStepControls();
+}
+
+function _updateStepControls() {
+    const total = _packedBoxes.length;
+    const ctrl  = document.getElementById('step-controls');
+    if (!ctrl) return;
+
+    const hasResult = total > 0;
+    ctrl.style.display = hasResult ? 'flex' : 'none';
+
+    document.getElementById('step-slider').max   = total;
+    document.getElementById('step-slider').value = _currentStep;
+    document.getElementById('step-label').textContent = `${_currentStep} / ${total}`;
+
+    document.getElementById('btn-step-first').disabled = _currentStep === 0;
+    document.getElementById('btn-step-prev').disabled  = _currentStep === 0;
+    document.getElementById('btn-step-next').disabled  = _currentStep === total;
+    document.getElementById('btn-step-last').disabled  = _currentStep === total;
+}
+
+function _stopPlay() {
+    if (_playTimer !== null) {
+        clearInterval(_playTimer);
+        _playTimer = null;
+    }
+    const btn = document.getElementById('btn-step-play');
+    if (btn) btn.textContent = '▶';
+}
+
+window.stepFirst = function() { _stopPlay(); _applyStep(0); };
+window.stepPrev  = function() { _stopPlay(); _applyStep(_currentStep - 1); };
+window.stepNext  = function() { _stopPlay(); _applyStep(_currentStep + 1); };
+window.stepLast  = function() { _stopPlay(); _applyStep(_packedBoxes.length); };
+
+window.togglePlay = function() {
+    if (_playTimer !== null) {
+        _stopPlay();
+        return;
+    }
+    // If already at end, restart from beginning
+    if (_currentStep >= _packedBoxes.length) _applyStep(0);
+    document.getElementById('btn-step-play').textContent = '⏸';
+    _playTimer = setInterval(() => {
+        if (_currentStep >= _packedBoxes.length) {
+            _stopPlay();
+        } else {
+            _applyStep(_currentStep + 1);
+        }
+    }, _playInterval);
+};
+
+window.onStepSlider = function(val) {
+    _stopPlay();
+    _applyStep(parseInt(val));
+};
+
+window.onSpeedChange = function(val) {
+    _playInterval = parseInt(val);
+    document.getElementById('speed-label').textContent = val + 'ms';
+};

--- a/js/viewer/BoxViewer.js
+++ b/js/viewer/BoxViewer.js
@@ -45,9 +45,12 @@ export class BoxViewer {
     _addGroundPlane() {
         const geo = new THREE.PlaneGeometry(8000, 8000);
         const mat = new THREE.MeshStandardMaterial({
-            color:     0xffffff,
-            roughness: 0.92,
-            metalness: 0.0
+            color:          0xffffff,
+            roughness:      0.92,
+            metalness:      0.0,
+            polygonOffset:      true,
+            polygonOffsetFactor: 1,
+            polygonOffsetUnits:  1
         });
         const plane = new THREE.Mesh(geo, mat);
         plane.rotation.x    = -Math.PI / 2;

--- a/js/viewer/RenderableContainer.js
+++ b/js/viewer/RenderableContainer.js
@@ -141,46 +141,41 @@ export class RenderableContainer extends Container {
         return group;
     }
 
-    // ── Shipping container: corrugated-steel mesh walls + ISO structure ────────
+    // ── Shipping container: cutaway cross-section view ────────────────────────
+    // Front (z=0) and left (x=0) walls are omitted so the interior is visible.
+    // Back and right walls are solid corrugated steel.
     _buildContainer() {
         const W = this.size.x, H = this.size.y, D = this.size.z;
         const yOff = this.palletHeight;
         const group = new THREE.Group();
 
         // Corrugation geometry parameters
-        // Ridge pitch ≈ 12 cm → realistic shipping-container corrugation
         const ridgeW = Math.max(8, Math.min(20, W * 0.04));
-        const amp    = ridgeW * 0.18;   // corrugation depth
+        const amp    = ridgeW * 0.18;
 
-        // ── Material for corrugated walls (semi-transparent steel) ─────────────
+        // ── Solid corrugated steel wall material ──────────────────────────────
         const wallMat = new THREE.MeshStandardMaterial({
-            color:       0xf0f2f5,
-            roughness:   0.45,
-            metalness:   0.55,
-            transparent: true,
-            opacity:     0.22,
-            side:        THREE.DoubleSide,
-            depthWrite:  false
+            color:       0xd8dde3,
+            roughness:   0.50,
+            metalness:   0.50,
+            side:        THREE.FrontSide
         });
 
-        const addWall = (geo, pos, rotY = 0) => {
-            const m = new THREE.Mesh(geo, wallMat.clone());
-            m.rotation.y = rotY;
-            m.position.copy(pos);
-            m.castShadow    = true;
-            m.receiveShadow = true;
-            group.add(m);
-        };
+        // Back wall (z=D) — visible from front
+        const backGeo = makeCorrugatedGeo(W, H, ridgeW, amp);
+        const back = new THREE.Mesh(backGeo, wallMat.clone());
+        back.rotation.y = Math.PI;
+        back.position.set(W/2, H/2 + yOff, D);
+        back.castShadow = back.receiveShadow = true;
+        group.add(back);
 
-        // Long walls (front z=0 / back z=D) — corrugations run vertically along width
-        const frontGeo = makeCorrugatedGeo(W, H, ridgeW, amp);
-        addWall(frontGeo,        new THREE.Vector3(W/2, H/2+yOff, 0));
-        addWall(makeCorrugatedGeo(W, H, ridgeW, amp), new THREE.Vector3(W/2, H/2+yOff, D), Math.PI);
-
-        // Short side walls (x=0 / x=W)
-        const sideGeo = makeCorrugatedGeo(D, H, ridgeW, amp);
-        addWall(sideGeo,                             new THREE.Vector3(0, H/2+yOff, D/2),  Math.PI/2);
-        addWall(makeCorrugatedGeo(D, H, ridgeW, amp), new THREE.Vector3(W, H/2+yOff, D/2), -Math.PI/2);
+        // Right wall (x=W) — visible from left
+        const rightGeo = makeCorrugatedGeo(D, H, ridgeW, amp);
+        const right = new THREE.Mesh(rightGeo, wallMat.clone());
+        right.rotation.y = -Math.PI / 2;
+        right.position.set(W, H/2 + yOff, D/2);
+        right.castShadow = right.receiveShadow = true;
+        group.add(right);
 
         // ── Floor (solid light-gray steel checker-plate) ──────────────────────
         const baseTex = TextureFactory.getMetalTexture();
@@ -188,8 +183,13 @@ export class RenderableContainer extends Container {
         const floor = new THREE.Mesh(
             new THREE.PlaneGeometry(W, D),
             new THREE.MeshStandardMaterial({
-                map: cloneTex(baseTex, W/TILE, D/TILE),
-                color: 0xd4d6d8, roughness: 0.88, metalness: 0.28
+                map:            cloneTex(baseTex, W/TILE, D/TILE),
+                color:          0xd4d6d8,
+                roughness:      0.88,
+                metalness:      0.28,
+                polygonOffset:      true,
+                polygonOffsetFactor: -1,
+                polygonOffsetUnits:  -1
             })
         );
         floor.rotation.x = -Math.PI / 2;
@@ -197,20 +197,9 @@ export class RenderableContainer extends Container {
         floor.receiveShadow = true;
         group.add(floor);
 
-        // ── Ceiling (semi-transparent corrugated) ─────────────────────────────
-        const ceilGeo = makeCorrugatedGeo(W, D, ridgeW, amp);
-        const ceil = new THREE.Mesh(ceilGeo, wallMat.clone());
-        // Ceiling plane is XZ, so rotate around X then reorient corrugations
-        ceil.rotation.x = Math.PI / 2;
-        ceil.position.set(W/2, yOff + H, D/2);
-        ceil.castShadow    = true;
-        ceil.receiveShadow = true;
-        group.add(ceil);
-
         // ── Structural steel: shared materials ────────────────────────────────
-        const postMat  = new THREE.MeshStandardMaterial({ color: 0xe8eaec, roughness: 0.48, metalness: 0.52 });
-        const railMat  = new THREE.MeshStandardMaterial({ color: 0xe2e4e6, roughness: 0.44, metalness: 0.56 });
-        const castMat  = new THREE.MeshStandardMaterial({ color: 0xd6d8dc, roughness: 0.38, metalness: 0.68 });
+        const postMat = new THREE.MeshStandardMaterial({ color: 0xe0e2e5, roughness: 0.48, metalness: 0.52 });
+        const railMat = new THREE.MeshStandardMaterial({ color: 0xd8dadd, roughness: 0.44, metalness: 0.56 });
 
         // Corner post thickness scales with container size
         const pw = Math.max(4, Math.min(W, D) * 0.030);
@@ -219,43 +208,25 @@ export class RenderableContainer extends Container {
         for (const [cx, cz] of [[pw/2,pw/2],[W-pw/2,pw/2],[pw/2,D-pw/2],[W-pw/2,D-pw/2]]) {
             const post = new THREE.Mesh(new THREE.BoxGeometry(pw, H, pw), postMat);
             post.position.set(cx, yOff + H/2, cz);
-            post.castShadow    = true;
-            post.receiveShadow = true;
+            post.castShadow = post.receiveShadow = true;
             group.add(post);
         }
 
-        // ── Top & bottom horizontal rails (4 edges each level) ───────────────
+        // ── Top & bottom horizontal rails ─────────────────────────────────────
         const rw = pw * 0.78;
         for (const ry of [yOff + rw/2, yOff + H - rw/2]) {
-            // Rails along X (front + back)
             for (const rz of [rw/2, D - rw/2]) {
                 const r = new THREE.Mesh(new THREE.BoxGeometry(W, rw, rw), railMat);
                 r.position.set(W/2, ry, rz);
-                r.castShadow    = true;
-                r.receiveShadow = true;
+                r.castShadow = r.receiveShadow = true;
                 group.add(r);
             }
-            // Rails along Z (left + right)
             for (const rx of [rw/2, W - rw/2]) {
                 const r = new THREE.Mesh(new THREE.BoxGeometry(rw, rw, D), railMat);
                 r.position.set(rx, ry, D/2);
-                r.castShadow    = true;
-                r.receiveShadow = true;
+                r.castShadow = r.receiveShadow = true;
                 group.add(r);
             }
-        }
-
-        // ── ISO corner castings at all 8 corners ──────────────────────────────
-        const cfw = pw * 1.90, cfh = pw * 1.30;
-        for (const [cx, cy, cz] of [
-            [0, yOff,   0], [W, yOff,   0], [0, yOff,   D], [W, yOff,   D],
-            [0, yOff+H, 0], [W, yOff+H, 0], [0, yOff+H, D], [W, yOff+H, D]
-        ]) {
-            const casting = new THREE.Mesh(new THREE.BoxGeometry(cfw, cfh, cfw), castMat);
-            casting.position.set(cx, cy, cz);
-            casting.castShadow    = true;
-            casting.receiveShadow = true;
-            group.add(casting);
         }
 
         return group;


### PR DESCRIPTION
- Fix z-fighting flicker between container floor and ground plane using
  polygonOffset on both the ground plane and the container floor mesh
- Remove ISO corner castings (the 8 corner cubes that made the shape
  look unrealistic)
- Replace fully-transparent container walls with a cutaway cross-section
  view: front and left walls omitted, back and right walls rendered as
  solid opaque corrugated steel, so the packing interior is always visible
- Add step-by-step packing playback controls below the 3D viewer:
  First/Prev/Play-Pause/Next/Last buttons, a step slider, a step counter,
  and a speed control slider (100–2000 ms per step)

https://claude.ai/code/session_01C9cfhfQ6w5zXas2jHsxbXj