### PR TITLE
Improve container rendering, box colors, and realistic dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,10 @@
                         <label class="form-label">预设</label>
                         <select class="form-control" id="container-preset" onchange="applyContainerPreset()">
                             <option value="">-- 自定义 --</option>
-                            <option value="0">小型集装箱 (200×220×200)</option>
-                            <option value="1">标准容器 (300×250×250)</option>
-                            <option value="2">货架格位 (120×100×80)</option>
+                            <option value="0">20尺集装箱 (589×239×235cm)</option>
+                            <option value="1">40尺集装箱 (1202×239×235cm)</option>
+                            <option value="2">40尺高柜 (1202×269×235cm)</option>
+                            <option value="3">货架格位 (120×100×80cm)</option>
                         </select>
                     </div>
 
@@ -66,15 +67,15 @@
                         <div class="dim-group">
                             <div>
                                 <div class="dim-label">宽 W</div>
-                                <input class="form-control" id="cont-w" type="number" step="1" value="300" min="1">
+                                <input class="form-control" id="cont-w" type="number" step="1" value="589" min="1">
                             </div>
                             <div>
                                 <div class="dim-label">高 H</div>
-                                <input class="form-control" id="cont-h" type="number" step="1" value="250" min="1">
+                                <input class="form-control" id="cont-h" type="number" step="1" value="239" min="1">
                             </div>
                             <div>
                                 <div class="dim-label">深 D</div>
-                                <input class="form-control" id="cont-d" type="number" step="1" value="250" min="1">
+                                <input class="form-control" id="cont-d" type="number" step="1" value="235" min="1">
                             </div>
                         </div>
                     </div>
@@ -86,7 +87,7 @@
 
                     <div style="margin-top:6px;">
                         <label class="form-label">&#x2696;&#xFE0F; 最大载重 (kg)</label>
-                        <input class="form-control" id="cont-maxweight" type="number" step="10" value="30000" min="0">
+                        <input class="form-control" id="cont-maxweight" type="number" step="10" value="28200" min="0">
                     </div>
 
                     <button class="btn btn-primary btn-block mt-2" onclick="applyContainer()">应用容器</button>

--- a/js/constants/presets.js
+++ b/js/constants/presets.js
@@ -3,6 +3,7 @@
     License: GPL-3.0 | Licensor: Elyar Adil
 */
 
+// Standard ISO shipping container interior dimensions (cm)
 export const BOX_PRESETS = [
     { label: '快递小箱',   width: 22, height:  9, depth: 17, weight: 0.5, maxWeightOnTop:  20 },
     { label: '快递中箱',   width: 31, height: 12, depth: 24, weight: 1,   maxWeightOnTop:  30 },
@@ -14,15 +15,17 @@ export const BOX_PRESETS = [
     { label: '仓储大箱',   width: 60, height: 40, depth: 40, weight: 5,   maxWeightOnTop: 100 }
 ];
 
+// Interior usable dimensions of standard ISO dry-cargo containers
 export const CONTAINER_PRESETS = [
-    { label: '小型集装箱', width: 200, height: 220, depth: 200, maxWeight: 20000 },
-    { label: '标准容器',   width: 300, height: 250, depth: 250, maxWeight: 30000 },
-    { label: '货架格位',   width: 120, height: 100, depth:  80, maxWeight:   500 }
+    { label: '20尺集装箱 (20ft)',    width: 589,  height: 239, depth: 235, maxWeight: 28200 },
+    { label: '40尺集装箱 (40ft)',    width: 1202, height: 239, depth: 235, maxWeight: 26750 },
+    { label: '40尺高柜 (40ft HC)',   width: 1202, height: 269, depth: 235, maxWeight: 26380 },
+    { label: '货架格位',             width: 120,  height: 100, depth:  80, maxWeight:   500 }
 ];
 
 export const PALLET_PRESETS = {
-    'EUR':   { width: 120,   height: 180, depth:  80,    deckHeight: 14.4, maxWeight: 1500, label: 'EUR托盘 (120×80cm)'      },
-    'US':    { width: 121.9, height: 180, depth: 101.6,  deckHeight: 14,   maxWeight: 1500, label: '美标托盘 (48×40in)'      },
-    'CN_T1': { width: 120,   height: 180, depth: 100,    deckHeight: 15,   maxWeight: 1200, label: '国标T1托盘 (120×100cm)'  },
-    'CN_T2': { width: 100,   height: 160, depth:  80,    deckHeight: 12,   maxWeight: 1000, label: '国标T2托盘 (100×80cm)'   }
+    'EUR':   { width: 120,   height: 180, depth:  80,   deckHeight: 14.4, maxWeight: 1500, label: 'EUR托盘 (120×80cm)'     },
+    'US':    { width: 121.9, height: 180, depth: 101.6, deckHeight: 14,   maxWeight: 1500, label: '美标托盘 (48×40in)'     },
+    'CN_T1': { width: 120,   height: 180, depth: 100,   deckHeight: 15,   maxWeight: 1200, label: '国标T1托盘 (120×100cm)' },
+    'CN_T2': { width: 100,   height: 160, depth:  80,   deckHeight: 12,   maxWeight: 1000, label: '国标T2托盘 (100×80cm)'  }
 };

--- a/js/main.js
+++ b/js/main.js
@@ -14,12 +14,28 @@ import { PanelManager } from './ui/PanelManager.js';
 import { StatsDisplay }  from './ui/StatsDisplay.js';
 import { BoxTable }       from './ui/BoxTable.js';
 
-// ─── Color palette ────────────────────────────────────────────────────────────
+// ─── Color palette (perceptually distinct, high-saturation colours) ────────────
 const COLOR_PALETTE = [
-    '#4e79a7','#f28e2b','#e15759','#76b7b2','#59a14f',
-    '#edc948','#b07aa1','#ff9da7','#9c755f','#bab0ac',
-    '#2ecc71','#e74c3c','#3498db','#9b59b6','#f39c12',
-    '#1abc9c','#e67e22','#d35400','#27ae60','#8e44ad'
+    '#e6194b', // vivid red
+    '#3cb44b', // vivid green
+    '#4169e1', // royal blue
+    '#ff8c00', // dark orange
+    '#911eb4', // purple
+    '#00ced1', // dark turquoise
+    '#ff69b4', // hot pink
+    '#8db600', // apple green
+    '#dc143c', // crimson
+    '#00bfff', // deep sky blue
+    '#ff6347', // tomato
+    '#7b68ee', // medium slate blue
+    '#20b2aa', // light sea green
+    '#ff1493', // deep pink
+    '#daa520', // goldenrod
+    '#4682b4', // steel blue
+    '#d2691e', // chocolate
+    '#9400d3', // dark violet
+    '#228b22', // forest green
+    '#ff4500', // orange-red
 ];
 let _colorIdx = 0;
 const nextColor = () => COLOR_PALETTE[_colorIdx++ % COLOR_PALETTE.length];
@@ -260,7 +276,7 @@ function _solveInternal() {
     const SolverClass = solverMap[selectedAlgo] || HeuristicSolver;
     const unpacked    = new SolverClass(container, appBoxes).solve();
 
-    // Store packed result and reset step state
+    // Store packed result; start animation from the beginning
     _packedBoxes = container.boxes.slice();
     _stopPlay();
     _currentStep = 0;
@@ -268,6 +284,11 @@ function _solveInternal() {
 
     _updateStepControls();
     statsDisplay.update(container.getStats(), appBoxes.length);
+
+    // Auto-play packing animation after a short render delay
+    if (_packedBoxes.length > 0) {
+        setTimeout(() => togglePlay(), 120);
+    }
 
     if (unpacked.length > 0) {
         const alertEl = document.getElementById('unpacked-alert');

--- a/js/viewer/RenderableBox.js
+++ b/js/viewer/RenderableBox.js
@@ -5,9 +5,9 @@
 
 /* global THREE */
 
-import { Box } from '../models/Box.js';
+import { Box }          from '../models/Box.js';
 import { TextureFactory } from './TextureFactory.js';
-import { getGroupColor } from './groupColors.js';
+import { getGroupColor }  from './groupColors.js';
 
 function cloneTex(baseTex, rx, ry) {
     const t = baseTex.clone();
@@ -16,34 +16,39 @@ function cloneTex(baseTex, rx, ry) {
     return t;
 }
 
-/** A Box with a Three.js mesh representing corrugated cardboard. */
+/**
+ * A Box with a Three.js mesh.
+ *
+ * Each box type (distinguished by `color` or `group`) renders with its own
+ * distinct colour applied directly to the material. The cardboard texture's
+ * near-white base lets the colour come through at full saturation, so boxes
+ * are easily told apart at a glance.
+ */
 export class RenderableBox extends Box {
     constructor(color, viewer, width, height, depth, options = {}) {
         super(width, height, depth, options);
         this.color  = color;
         this.viewer = viewer;
 
-        const finalColor = options.group ? (getGroupColor(options.group) ?? color) : color;
-        const TILE = 40; // cm per texture tile
-        const baseTex = TextureFactory.getCardboardTexture();
+        // Group color overrides individual color when a group is set
+        const faceColor = options.group ? (getGroupColor(options.group) ?? color) : color;
 
-        // Use white color so the cardboard texture shows its natural warm brown.
-        // Group identity is conveyed via a subtle emissive tint + colored edge lines.
-        // (Multiplying the group color directly onto the texture would produce near-black.)
-        const emissiveColor = new THREE.Color(finalColor).multiplyScalar(0.22);
-        const texScale = Math.max(1, (width + depth) * 0.5 / TILE);
+        const TILE      = 40; // cm per texture tile
+        const texScale  = Math.max(1, (width + depth) * 0.5 / TILE);
         const texScaleH = Math.max(1, height / TILE);
-        const tex       = cloneTex(baseTex, texScale, texScaleH);
-        const normalTex = cloneTex(TextureFactory.getCardboardNormalMap(), texScale, texScaleH);
+        const baseTex   = TextureFactory.getCardboardTexture();
+
         const material = new THREE.MeshStandardMaterial({
-            map:                 tex,
-            normalMap:           normalTex,
-            normalScale:         new THREE.Vector2(0.6, 0.6),
-            color:               0xffffff,      // white → texture shows naturally
-            emissive:            emissiveColor, // soft group-color glow
-            opacity:             options.fragile ? 0.78 : 1.0,
+            // Apply the assigned colour directly — the near-white cardboard
+            // texture modulates it, giving a naturally-tinted cardboard look.
+            color:               new THREE.Color(faceColor),
+            map:                 cloneTex(baseTex, texScale, texScaleH),
+            normalMap:           cloneTex(TextureFactory.getCardboardNormalMap(), texScale, texScaleH),
+            normalScale:         new THREE.Vector2(0.5, 0.5),
+            emissive:            new THREE.Color(0x000000),
+            opacity:             options.fragile ? 0.75 : 1.0,
             metalness:           0.0,
-            roughness:           0.80,
+            roughness:           0.82,
             transparent:         !!options.fragile,
             polygonOffset:       true,
             polygonOffsetFactor: 1,
@@ -56,8 +61,12 @@ export class RenderableBox extends Box {
         this.mesh.receiveShadow = true;
         this.mesh.visible       = false;
 
-        // Edge lines use group color — primary visual identifier for each box group
-        const edgeMat = new THREE.LineBasicMaterial({ color: finalColor, opacity: 0.85, transparent: true });
+        // Dark edge lines — sharply visible against any box colour
+        const edgeMat = new THREE.LineBasicMaterial({
+            color:       0x000000,
+            opacity:     0.45,
+            transparent: true
+        });
         this.edges = new THREE.LineSegments(new THREE.EdgesGeometry(geometry), edgeMat);
         this.mesh.add(this.edges);
 
@@ -68,7 +77,7 @@ export class RenderableBox extends Box {
     }
 
     _addFragileIndicator() {
-        const mat = new THREE.LineBasicMaterial({ color: 0xff2200, linewidth: 2 });
+        const mat  = new THREE.LineBasicMaterial({ color: 0xff2200, linewidth: 2 });
         const pts1 = [new THREE.Vector3(-0.5, 0.5, -0.5), new THREE.Vector3( 0.5, 0.5,  0.5)];
         const pts2 = [new THREE.Vector3( 0.5, 0.5, -0.5), new THREE.Vector3(-0.5, 0.5,  0.5)];
         this.mesh.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(pts1), mat));

--- a/js/viewer/RenderableContainer.js
+++ b/js/viewer/RenderableContainer.js
@@ -6,8 +6,10 @@
 /* global THREE */
 
 import { Container } from '../models/Container.js';
-import { Vector3D } from '../models/Vector3D.js';
+import { Vector3D }   from '../models/Vector3D.js';
 import { TextureFactory } from './TextureFactory.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 function cloneTex(baseTex, rx, ry) {
     const t = baseTex.clone();
@@ -17,25 +19,23 @@ function cloneTex(baseTex, rx, ry) {
 }
 
 /**
- * Build a corrugated PlaneGeometry where vertices are displaced in Z
- * to form actual sine-wave ridges (not just a texture effect).
+ * Corrugated PlaneBufferGeometry: sine-wave vertex displacement in local Z.
+ * Ridges run along the height axis, spaced across the width axis.
  *
- * @param {number} width   - total width of the plane
- * @param {number} height  - total height of the plane
- * @param {number} ridgeW  - approximate ridge pitch (cm)
- * @param {number} amp     - ridge amplitude (depth of corrugation)
+ * @param {number} width   – plane width  (cm)
+ * @param {number} height  – plane height (cm)
+ * @param {number} ridgeW  – ridge pitch  (cm)
+ * @param {number} amp     – ridge amplitude (cm)
  */
 function makeCorrugatedGeo(width, height, ridgeW, amp) {
-    const numRidges  = Math.max(4, Math.round(width / ridgeW));
-    const segsX      = numRidges * 8;   // 8 verts per ridge → smooth sine
-    const segsY      = Math.max(2, Math.round(height / ridgeW));
-    // Must use PlaneBufferGeometry (not PlaneGeometry) in r81 to get BufferAttribute API
-    const geo        = new THREE.PlaneBufferGeometry(width, height, segsX, segsY);
-    const pos        = geo.attributes.position;
+    const numRidges = Math.max(4, Math.round(width / ridgeW));
+    const segsX     = numRidges * 8;   // 8 verts per ridge → smooth sine curve
+    const segsY     = Math.max(2, Math.round(height / ridgeW));
+    const geo       = new THREE.PlaneBufferGeometry(width, height, segsX, segsY);
+    const pos       = geo.attributes.position;
 
     for (let i = 0; i < pos.count; i++) {
-        const x = pos.getX(i);           // local plane x ∈ [-w/2, w/2]
-        // Sine wave across width: one full period = ridgeW
+        const x = pos.getX(i);
         const t = (x / width + 0.5) * Math.PI * 2 * numRidges;
         pos.setZ(i, Math.sin(t) * amp);
     }
@@ -44,14 +44,44 @@ function makeCorrugatedGeo(width, height, ridgeW, amp) {
     return geo;
 }
 
-/** A Container with Three.js visualization (wireframe + pallet or shipping-container detail). */
+/** Shared corrugated steel wall material (cloned per mesh). */
+function makeWallMat(color = 0xc8d0d8) {
+    return new THREE.MeshStandardMaterial({
+        color,
+        roughness:   0.45,
+        metalness:   0.55,
+        side:        THREE.FrontSide
+    });
+}
+
+/** Ghost glass panel for see-through walls. */
+function makeGhostMat() {
+    return new THREE.MeshStandardMaterial({
+        color:      0xbdd8f0,
+        roughness:  0.08,
+        metalness:  0.15,
+        opacity:    0.18,
+        transparent: true,
+        side:        THREE.DoubleSide,
+        depthWrite:  false
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A Container with Three.js visualization.
+ * Renders either a full 6-sided shipping container (solid back/right/top/floor
+ * + ghost front/left walls) or a wooden pallet.
+ */
 export class RenderableContainer extends Container {
     constructor(viewer, width, height, depth, options = {}) {
         super(width || 1, height || 1, depth || 1, options);
 
+        // Bounding-box wireframe (all 12 edges) – always visible
         this.mesh = new THREE.LineSegments(
             new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
-            new THREE.LineBasicMaterial({ color: 0x888888 })
+            new THREE.LineBasicMaterial({ color: 0x6a7480 })
         );
 
         this.viewer       = viewer;
@@ -61,29 +91,43 @@ export class RenderableContainer extends Container {
         viewer.container = this;
     }
 
+    /** Resize the container and rebuild its 3-D detail geometry. */
     changeSize(width, height, depth, options = {}) {
-        this.size        = new Vector3D(width, height, depth);
-        this.isPallet    = options.isPallet    || false;
+        this.size         = new Vector3D(width, height, depth);
+        this.isPallet     = options.isPallet     || false;
         this.palletHeight = options.palletHeight || 0;
-        this.maxWeight   = options.maxWeight !== undefined ? options.maxWeight : Infinity;
+        this.maxWeight    = options.maxWeight !== undefined ? options.maxWeight : Infinity;
 
         const yOffset = this.palletHeight;
         this.mesh.scale.set(width, height, depth);
         this.mesh.position.set(width / 2, height / 2 + yOffset, depth / 2);
-        this.mesh.material.color.setHex(this.isPallet ? 0x777766 : 0x555a60);
+        this.mesh.material.color.setHex(this.isPallet ? 0x776655 : 0x4a5560);
 
-        this.viewer.controls.target.set(width / 2, (height + yOffset) / 2, depth / 2);
+        this.viewer.controls.target.set(width / 2, (height / 2) + yOffset, depth / 2);
+        this._resetCamera(width, height, depth, yOffset);
         this._rebuildDetail();
+    }
+
+    /** Position camera to frame the container nicely. */
+    _resetCamera(W, H, D, yOffset) {
+        const maxDim = Math.max(W, H, D);
+        const dist   = maxDim * 1.6 + 300;
+        // Offset toward front-right-above for a natural isometric feel
+        this.viewer.camera.position.set(
+            W * 0.65 + dist * 0.35,
+            H * 0.8  + yOffset + dist * 0.25,
+            D        + dist * 0.40
+        );
     }
 
     _rebuildDetail() {
         if (this._detailGroup) {
             this.viewer.scene.remove(this._detailGroup);
-            this._detailGroup.traverse(c => {
-                if (c.geometry) c.geometry.dispose();
-                if (c.material) {
-                    (Array.isArray(c.material) ? c.material : [c.material])
-                        .forEach(m => { m.map = null; m.dispose(); });
+            this._detailGroup.traverse(child => {
+                if (child.geometry) child.geometry.dispose();
+                if (child.material) {
+                    const mats = Array.isArray(child.material) ? child.material : [child.material];
+                    mats.forEach(m => { if (m.map) m.map.dispose(); m.dispose(); });
                 }
             });
             this._detailGroup = null;
@@ -93,14 +137,14 @@ export class RenderableContainer extends Container {
         if (this._detailGroup) this.viewer.scene.add(this._detailGroup);
     }
 
-    // ── Wooden pallet: top planks + 3 stringers + bottom boards ──────────────
+    // ── Wooden pallet ─────────────────────────────────────────────────────────
     _buildPallet() {
         const W = this.size.x, D = this.size.z, H = this.palletHeight;
         if (H <= 0) return null;
 
-        const group    = new THREE.Group();
-        const baseTex  = TextureFactory.getWoodTexture();
-        const TILE     = 50;
+        const group   = new THREE.Group();
+        const baseTex = TextureFactory.getWoodTexture();
+        const TILE    = 50;
 
         const mkMat = (col, rx, ry) => new THREE.MeshStandardMaterial({
             map: cloneTex(baseTex, rx, ry), color: col, roughness: 0.87, metalness: 0.0
@@ -108,31 +152,37 @@ export class RenderableContainer extends Container {
 
         const topH = H * 0.27, btmH = H * 0.15, strH = H - topH - btmH;
 
-        // Top deck — 5 planks
+        // Top deck – 5 planks with small gaps
         for (let i = 0; i < 5; i++) {
             const pw = W / 5, gap = pw * 0.10;
-            const geo = new THREE.BoxGeometry(pw - gap, topH, D);
-            const m = new THREE.Mesh(geo, mkMat(0xc8a070, (pw - gap) / TILE, D / TILE));
+            const m = new THREE.Mesh(
+                new THREE.BoxGeometry(pw - gap, topH, D),
+                mkMat(0xc8a070, (pw - gap) / TILE, D / TILE)
+            );
             m.position.set((i + 0.5) * pw, H - topH / 2, D / 2);
             m.castShadow = m.receiveShadow = true;
             group.add(m);
         }
 
-        // 3 stringers
+        // 3 longitudinal stringers
         const sW = W * 0.12;
         for (const sx of [W * 0.10, W * 0.50, W * 0.90]) {
-            const geo = new THREE.BoxGeometry(sW, strH, D);
-            const m = new THREE.Mesh(geo, mkMat(0x8a5530, sW / TILE, D / TILE));
+            const m = new THREE.Mesh(
+                new THREE.BoxGeometry(sW, strH, D),
+                mkMat(0x8a5530, sW / TILE, D / TILE)
+            );
             m.position.set(sx, btmH + strH / 2, D / 2);
             m.castShadow = m.receiveShadow = true;
             group.add(m);
         }
 
-        // Bottom boards — 3
+        // Bottom boards – 3
         for (let i = 0; i < 3; i++) {
             const bw = W / 3, gap = bw * 0.06;
-            const geo = new THREE.BoxGeometry(bw - gap, btmH, D);
-            const m = new THREE.Mesh(geo, mkMat(0xb89060, (bw - gap) / TILE, D / TILE));
+            const m = new THREE.Mesh(
+                new THREE.BoxGeometry(bw - gap, btmH, D),
+                mkMat(0xb89060, (bw - gap) / TILE, D / TILE)
+            );
             m.position.set((i + 0.5) * bw, btmH / 2, D / 2);
             m.castShadow = m.receiveShadow = true;
             group.add(m);
@@ -141,92 +191,139 @@ export class RenderableContainer extends Container {
         return group;
     }
 
-    // ── Shipping container: cutaway cross-section view ────────────────────────
-    // Front (z=0) and left (x=0) walls are omitted so the interior is visible.
-    // Back and right walls are solid corrugated steel.
+    // ── Shipping container ────────────────────────────────────────────────────
+    // All 6 sides are rendered:
+    //   • Back (z=D), Right (x=W), Top (y=H), Floor (y=0) → solid corrugated steel
+    //   • Front (z=0), Left (x=0)                         → ghost glass panels
+    // Corner posts and horizontal rails complete the frame.
     _buildContainer() {
         const W = this.size.x, H = this.size.y, D = this.size.z;
         const yOff = this.palletHeight;
         const group = new THREE.Group();
 
-        // Corrugation geometry parameters
-        const ridgeW = Math.max(8, Math.min(20, W * 0.04));
-        const amp    = ridgeW * 0.18;
+        const ridgeW = Math.max(6, Math.min(18, W * 0.035));
+        const amp    = ridgeW * 0.20;
+        const TILE   = 110;
 
-        // ── Solid corrugated steel wall material ──────────────────────────────
-        const wallMat = new THREE.MeshStandardMaterial({
-            color:       0xd8dde3,
-            roughness:   0.50,
-            metalness:   0.50,
-            side:        THREE.FrontSide
-        });
+        // ── Solid steel material (one per face to allow independent opacity) ──
+        const solidMat = () => makeWallMat(0xc8d0d8);
 
-        // Back wall (z=D) — visible from front
-        const backGeo = makeCorrugatedGeo(W, H, ridgeW, amp);
-        const back = new THREE.Mesh(backGeo, wallMat.clone());
-        back.rotation.y = Math.PI;
-        back.position.set(W/2, H/2 + yOff, D);
-        back.castShadow = back.receiveShadow = true;
-        group.add(back);
+        // Back wall (z = D) — closed end of container, faces −Z
+        {
+            const geo  = makeCorrugatedGeo(W, H, ridgeW, amp);
+            const mesh = new THREE.Mesh(geo, solidMat());
+            mesh.rotation.y = Math.PI;
+            mesh.position.set(W / 2, H / 2 + yOff, D);
+            mesh.castShadow = mesh.receiveShadow = true;
+            group.add(mesh);
+        }
 
-        // Right wall (x=W) — visible from left
-        const rightGeo = makeCorrugatedGeo(D, H, ridgeW, amp);
-        const right = new THREE.Mesh(rightGeo, wallMat.clone());
-        right.rotation.y = -Math.PI / 2;
-        right.position.set(W, H/2 + yOff, D/2);
-        right.castShadow = right.receiveShadow = true;
-        group.add(right);
+        // Right wall (x = W) — faces −X from outside
+        {
+            const geo  = makeCorrugatedGeo(D, H, ridgeW, amp);
+            const mesh = new THREE.Mesh(geo, solidMat());
+            mesh.rotation.y = -Math.PI / 2;
+            mesh.position.set(W, H / 2 + yOff, D / 2);
+            mesh.castShadow = mesh.receiveShadow = true;
+            group.add(mesh);
+        }
 
-        // ── Floor (solid light-gray steel checker-plate) ──────────────────────
-        const baseTex = TextureFactory.getMetalTexture();
-        const TILE = 110;
-        const floor = new THREE.Mesh(
-            new THREE.PlaneGeometry(W, D),
-            new THREE.MeshStandardMaterial({
-                map:            cloneTex(baseTex, W/TILE, D/TILE),
-                color:          0xd4d6d8,
-                roughness:      0.88,
-                metalness:      0.28,
-                polygonOffset:      true,
-                polygonOffsetFactor: -1,
-                polygonOffsetUnits:  -1
-            })
-        );
-        floor.rotation.x = -Math.PI / 2;
-        floor.position.set(W/2, yOff, D/2);
-        floor.receiveShadow = true;
-        group.add(floor);
+        // Top wall (y = H) — corrugated roof, slightly transparent for interior visibility
+        {
+            const geo  = makeCorrugatedGeo(W, D, ridgeW, amp);
+            const mat  = solidMat();
+            mat.opacity     = 0.72;
+            mat.transparent = true;
+            mat.depthWrite  = false;
+            const mesh = new THREE.Mesh(geo, mat);
+            mesh.rotation.x = -Math.PI / 2;
+            mesh.position.set(W / 2, H + yOff, D / 2);
+            mesh.receiveShadow = true;
+            group.add(mesh);
+        }
 
-        // ── Structural steel: shared materials ────────────────────────────────
-        const postMat = new THREE.MeshStandardMaterial({ color: 0xe0e2e5, roughness: 0.48, metalness: 0.52 });
-        const railMat = new THREE.MeshStandardMaterial({ color: 0xd8dadd, roughness: 0.44, metalness: 0.56 });
+        // Floor (y = 0) — metal checker-plate
+        {
+            const baseTex = TextureFactory.getMetalTexture();
+            const mesh    = new THREE.Mesh(
+                new THREE.PlaneGeometry(W, D),
+                new THREE.MeshStandardMaterial({
+                    map:                  cloneTex(baseTex, W / TILE, D / TILE),
+                    color:                0xd0d4d8,
+                    roughness:            0.85,
+                    metalness:            0.30,
+                    polygonOffset:        true,
+                    polygonOffsetFactor: -1,
+                    polygonOffsetUnits:  -1
+                })
+            );
+            mesh.rotation.x = -Math.PI / 2;
+            mesh.position.set(W / 2, yOff, D / 2);
+            mesh.receiveShadow = true;
+            group.add(mesh);
+        }
 
-        // Corner post thickness scales with container size
-        const pw = Math.max(4, Math.min(W, D) * 0.030);
+        // Ghost front wall (z = 0) — loading-door end, see-through
+        {
+            const mesh = new THREE.Mesh(new THREE.PlaneGeometry(W, H), makeGhostMat());
+            mesh.position.set(W / 2, H / 2 + yOff, 0);
+            group.add(mesh);
+        }
 
-        // ── 4 Vertical corner posts ───────────────────────────────────────────
-        for (const [cx, cz] of [[pw/2,pw/2],[W-pw/2,pw/2],[pw/2,D-pw/2],[W-pw/2,D-pw/2]]) {
+        // Ghost left wall (x = 0) — see-through side
+        {
+            const mesh = new THREE.Mesh(new THREE.PlaneGeometry(D, H), makeGhostMat());
+            mesh.rotation.y = Math.PI / 2;
+            mesh.position.set(0, H / 2 + yOff, D / 2);
+            group.add(mesh);
+        }
+
+        // ── Structural frame: corner posts + horizontal rails ─────────────────
+        const pw      = Math.max(4, Math.min(W, D) * 0.025);
+        const postMat = new THREE.MeshStandardMaterial({ color: 0xdde0e4, roughness: 0.45, metalness: 0.58 });
+        const railMat = new THREE.MeshStandardMaterial({ color: 0xd5d8dc, roughness: 0.42, metalness: 0.60 });
+
+        // 4 vertical corner posts
+        for (const [cx, cz] of [
+            [pw / 2,     pw / 2    ],
+            [W - pw / 2, pw / 2    ],
+            [pw / 2,     D - pw / 2],
+            [W - pw / 2, D - pw / 2]
+        ]) {
             const post = new THREE.Mesh(new THREE.BoxGeometry(pw, H, pw), postMat);
-            post.position.set(cx, yOff + H/2, cz);
+            post.position.set(cx, yOff + H / 2, cz);
             post.castShadow = post.receiveShadow = true;
             group.add(post);
         }
 
-        // ── Top & bottom horizontal rails ─────────────────────────────────────
-        const rw = pw * 0.78;
-        for (const ry of [yOff + rw/2, yOff + H - rw/2]) {
-            for (const rz of [rw/2, D - rw/2]) {
+        // Top & bottom horizontal rails along width and depth
+        const rw = pw * 0.80;
+        for (const ry of [yOff + rw / 2, yOff + H - rw / 2]) {
+            // Along width (X axis)
+            for (const rz of [rw / 2, D - rw / 2]) {
                 const r = new THREE.Mesh(new THREE.BoxGeometry(W, rw, rw), railMat);
-                r.position.set(W/2, ry, rz);
+                r.position.set(W / 2, ry, rz);
                 r.castShadow = r.receiveShadow = true;
                 group.add(r);
             }
-            for (const rx of [rw/2, W - rw/2]) {
+            // Along depth (Z axis)
+            for (const rx of [rw / 2, W - rw / 2]) {
                 const r = new THREE.Mesh(new THREE.BoxGeometry(rw, rw, D), railMat);
-                r.position.set(rx, ry, D/2);
+                r.position.set(rx, ry, D / 2);
                 r.castShadow = r.receiveShadow = true;
                 group.add(r);
             }
+        }
+
+        // Door seam: vertical dividing line on back wall (centre)
+        {
+            const seamMat = new THREE.LineBasicMaterial({ color: 0xa0a8b0, linewidth: 1 });
+            const pts     = [
+                new THREE.Vector3(W / 2, yOff,      D + amp + 1),
+                new THREE.Vector3(W / 2, yOff + H,  D + amp + 1)
+            ];
+            const seam = new THREE.Line(new THREE.BufferGeometry().setFromPoints(pts), seamMat);
+            group.add(seam);
         }
 
         return group;

--- a/js/viewer/TextureFactory.js
+++ b/js/viewer/TextureFactory.js
@@ -5,64 +5,56 @@
 
 /* global THREE */
 
-/** Singleton factory that generates and caches procedural Three.js textures. */
+/**
+ * Singleton factory: generates and caches procedural Three.js textures.
+ * The cardboard texture uses a near-white base so that the MeshStandardMaterial
+ * `color` property (set per-box) renders with full saturation.
+ */
 export class TextureFactory {
     static _cardboardTex    = null;
     static _cardboardNormal = null;
     static _woodTex         = null;
     static _metalTex        = null;
 
-    static getCardboardTexture() {
-        if (!TextureFactory._cardboardTex)
-            TextureFactory._cardboardTex = TextureFactory._makeCardboard();
-        return TextureFactory._cardboardTex;
-    }
+    static getCardboardTexture()  { return TextureFactory._cardboardTex    ??= TextureFactory._makeCardboard(); }
+    static getCardboardNormalMap(){ return TextureFactory._cardboardNormal ??= TextureFactory._makeCardboardNormal(); }
+    static getWoodTexture()       { return TextureFactory._woodTex         ??= TextureFactory._makeWood(); }
+    static getMetalTexture()      { return TextureFactory._metalTex        ??= TextureFactory._makeMetal(); }
 
-    static getCardboardNormalMap() {
-        if (!TextureFactory._cardboardNormal)
-            TextureFactory._cardboardNormal = TextureFactory._makeCardboardNormal();
-        return TextureFactory._cardboardNormal;
-    }
-
-    static getWoodTexture() {
-        if (!TextureFactory._woodTex)
-            TextureFactory._woodTex = TextureFactory._makeWood();
-        return TextureFactory._woodTex;
-    }
-
-    static getMetalTexture() {
-        if (!TextureFactory._metalTex)
-            TextureFactory._metalTex = TextureFactory._makeMetal();
-        return TextureFactory._metalTex;
-    }
-
-    // ── Corrugated cardboard — warm brown with horizontal flute lines ─────────
+    // ── Near-white corrugated cardboard ───────────────────────────────────────
+    // Base is very light warm-white so the material `color` tints it vividly.
     static _makeCardboard() {
-        const S = 512, cv = document.createElement('canvas');
+        const S = 512;
+        const cv = document.createElement('canvas');
         cv.width = cv.height = S;
         const ctx = cv.getContext('2d');
 
-        ctx.fillStyle = '#c4986a';
+        // Near-white warm base
+        ctx.fillStyle = '#f2ede6';
         ctx.fillRect(0, 0, S, S);
 
-        for (let y = 0; y < S; y += 5) {
-            ctx.fillStyle = `rgba(0,0,0,${(0.05 + Math.random() * 0.04).toFixed(3)})`;
+        // Horizontal flute lines (corrugated cardboard profile)
+        for (let y = 0; y < S; y += 6) {
+            ctx.fillStyle = `rgba(0,0,0,${(0.06 + Math.random() * 0.04).toFixed(3)})`;
             ctx.fillRect(0, y, S, 1);
-            ctx.fillStyle = `rgba(255,220,160,${(0.04 + Math.random() * 0.03).toFixed(3)})`;
-            ctx.fillRect(0, y + 2, S, 1);
+            ctx.fillStyle = `rgba(255,255,255,${(0.08 + Math.random() * 0.05).toFixed(3)})`;
+            ctx.fillRect(0, y + 3, S, 1);
         }
-        for (let x = 60; x < S; x += 60) {
-            ctx.strokeStyle = `rgba(0,0,0,${(0.06 + Math.random() * 0.04).toFixed(3)})`;
+
+        // Subtle vertical panel-edge lines
+        for (let x = 80; x < S; x += 80) {
+            ctx.strokeStyle = `rgba(0,0,0,${(0.05 + Math.random() * 0.03).toFixed(3)})`;
             ctx.lineWidth = 1;
             ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, S); ctx.stroke();
         }
 
+        // Fine noise for surface variation
         const id = ctx.getImageData(0, 0, S, S), d = id.data;
         for (let i = 0; i < d.length; i += 4) {
-            const n = (Math.random() - 0.5) * 22;
-            d[i]   = Math.max(0, Math.min(255, d[i]   + n));
-            d[i+1] = Math.max(0, Math.min(255, d[i+1] + n * 0.8));
-            d[i+2] = Math.max(0, Math.min(255, d[i+2] + n * 0.4));
+            const n = (Math.random() - 0.5) * 14;
+            d[i]     = Math.max(0, Math.min(255, d[i]     + n));
+            d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + n));
+            d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + n * 0.8));
         }
         ctx.putImageData(id, 0, 0);
 
@@ -73,18 +65,22 @@ export class TextureFactory {
 
     // ── Wood grain — pine pallet planks ───────────────────────────────────────
     static _makeWood() {
-        const S = 512, cv = document.createElement('canvas');
+        const S = 512;
+        const cv = document.createElement('canvas');
         cv.width = cv.height = S;
         const ctx = cv.getContext('2d');
 
         ctx.fillStyle = '#9a6b32';
         ctx.fillRect(0, 0, S, S);
 
+        // Plank colour bands
         for (let x = 0; x < S; x += 48) {
             const l = 130 + Math.floor(Math.random() * 35);
             ctx.fillStyle = `rgba(${l},${Math.floor(l * 0.62)},${Math.floor(l * 0.3)},0.18)`;
             ctx.fillRect(x, 0, 48, S);
         }
+
+        // Wood grain lines
         for (let i = 0; i < 160; i++) {
             const y0 = Math.random() * S;
             ctx.strokeStyle = `rgba(0,0,0,${(0.03 + Math.random() * 0.09).toFixed(3)})`;
@@ -94,6 +90,8 @@ export class TextureFactory {
             for (let x = 0; x <= S; x += 40) { py += (Math.random() - 0.5) * 5; ctx.lineTo(x, py); }
             ctx.stroke();
         }
+
+        // Knots
         for (let k = 0; k < 4; k++) {
             const kx = Math.random() * S, ky = Math.random() * S, kr = 8 + Math.random() * 16;
             for (let r = kr; r > 1; r -= 2) {
@@ -102,6 +100,8 @@ export class TextureFactory {
                 ctx.beginPath(); ctx.ellipse(kx, ky, r, r * 0.55, Math.PI / 5, 0, Math.PI * 2); ctx.stroke();
             }
         }
+
+        // Cross-grain plank joints
         for (let y = 55; y < S; y += 55 + Math.floor(Math.random() * 8)) {
             ctx.strokeStyle = 'rgba(0,0,0,0.30)'; ctx.lineWidth = 2;
             ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(S, y); ctx.stroke();
@@ -112,9 +112,9 @@ export class TextureFactory {
         const id = ctx.getImageData(0, 0, S, S), d = id.data;
         for (let i = 0; i < d.length; i += 4) {
             const n = (Math.random() - 0.5) * 16;
-            d[i]   = Math.max(0, Math.min(255, d[i]   + n));
-            d[i+1] = Math.max(0, Math.min(255, d[i+1] + n));
-            d[i+2] = Math.max(0, Math.min(255, d[i+2] + n));
+            d[i]     = Math.max(0, Math.min(255, d[i]     + n));
+            d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + n));
+            d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + n));
         }
         ctx.putImageData(id, 0, 0);
 
@@ -123,41 +123,37 @@ export class TextureFactory {
         return tex;
     }
 
-    // ── Corrugated steel — white shipping container panels ────────────────────
+    // ── Corrugated steel — white-painted shipping container panels ────────────
     static _makeMetal() {
-        const S = 512, cv = document.createElement('canvas');
+        const S = 512;
+        const cv = document.createElement('canvas');
         cv.width = cv.height = S;
         const ctx = cv.getContext('2d');
 
-        // Near-white base (standard white-painted shipping container)
         ctx.fillStyle = '#eceef0';
         ctx.fillRect(0, 0, S, S);
 
-        // Strong vertical corrugation ridges (sine-wave profile: dark valley → bright peak)
-        // ridgeWidth = 60px → ~8.5 ridges per 512 texture
-        // With TILE=110 on a W=300 container: ~23 ridges total (realistic for a 20ft container)
+        // Corrugation ridges (vertical strips, ~8 ridges per tile)
         const rw = 60;
         for (let x = 0; x < S; x += rw) {
-            // Corrugation profile: valley(dark) → face → peak(bright) → face → valley(dark)
             const g = ctx.createLinearGradient(x, 0, x + rw, 0);
-            g.addColorStop(0,    'rgba(0,0,0,0.32)');   // deep valley shadow
-            g.addColorStop(0.12, 'rgba(0,0,0,0.10)');
-            g.addColorStop(0.28, 'rgba(255,255,255,0.28)'); // ascending face
-            g.addColorStop(0.45, 'rgba(255,255,255,0.42)'); // ridge peak highlight
-            g.addColorStop(0.60, 'rgba(255,255,255,0.18)'); // descending face
-            g.addColorStop(0.80, 'rgba(0,0,0,0.08)');
-            g.addColorStop(1,    'rgba(0,0,0,0.30)');   // next valley shadow
+            g.addColorStop(0,    'rgba(0,0,0,0.30)');
+            g.addColorStop(0.12, 'rgba(0,0,0,0.08)');
+            g.addColorStop(0.28, 'rgba(255,255,255,0.26)');
+            g.addColorStop(0.45, 'rgba(255,255,255,0.40)');
+            g.addColorStop(0.60, 'rgba(255,255,255,0.16)');
+            g.addColorStop(0.80, 'rgba(0,0,0,0.06)');
+            g.addColorStop(1,    'rgba(0,0,0,0.28)');
             ctx.fillStyle = g;
             ctx.fillRect(x, 0, rw, S);
         }
 
-        // Fine noise for slight surface texture variation
         const id = ctx.getImageData(0, 0, S, S), d = id.data;
         for (let i = 0; i < d.length; i += 4) {
-            const n = (Math.random() - 0.5) * 7;
-            d[i]   = Math.max(0, Math.min(255, d[i]   + n));
-            d[i+1] = Math.max(0, Math.min(255, d[i+1] + n));
-            d[i+2] = Math.max(0, Math.min(255, d[i+2] + n));
+            const n = (Math.random() - 0.5) * 6;
+            d[i]     = Math.max(0, Math.min(255, d[i]     + n));
+            d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + n));
+            d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + n));
         }
         ctx.putImageData(id, 0, 0);
 
@@ -168,28 +164,22 @@ export class TextureFactory {
 
     // ── Cardboard normal map — horizontal flute ridges for PBR depth ──────────
     static _makeCardboardNormal() {
-        const S = 512, cv = document.createElement('canvas');
+        const S = 512;
+        const cv = document.createElement('canvas');
         cv.width = cv.height = S;
         const ctx = cv.getContext('2d');
 
-        // Base normal pointing straight out: RGB(128, 128, 255)
-        ctx.fillStyle = '#8080ff';
+        ctx.fillStyle = '#8080ff'; // flat normal (0,0,1)
         ctx.fillRect(0, 0, S, S);
 
         const id = ctx.getImageData(0, 0, S, S), d = id.data;
-        // Corrugated flute period: ~10 pixels → ~50 ridges per tile
-        const period = 10;
+        const period = 10; // flute period in pixels
         for (let i = 0; i < d.length; i += 4) {
-            const py = Math.floor(i / 4 / S); // pixel row
-            const t  = (py / period) * Math.PI * 2;
-            // Ny encodes vertical slope of the sine ridge profile
-            const slope = Math.cos(t);  // derivative of sin
-            // Normal: Nx=0 (128), Ny=slope*60, Nz=high (215-255)
-            const ny = Math.max(0, Math.min(255, 128 + slope * 55));
-            const nz = Math.max(180, Math.min(255, 220 - Math.abs(slope) * 30));
-            d[i]     = 128; // R = Nx (neutral)
-            d[i + 1] = ny;  // G = Ny (tilt up/down)
-            d[i + 2] = nz;  // B = Nz
+            const py    = Math.floor(i / 4 / S);
+            const slope = Math.cos((py / period) * Math.PI * 2);
+            d[i]     = 128;
+            d[i + 1] = Math.max(0, Math.min(255, 128 + slope * 55));
+            d[i + 2] = Math.max(180, Math.min(255, 220 - Math.abs(slope) * 30));
             d[i + 3] = 255;
         }
         ctx.putImageData(id, 0, 0);


### PR DESCRIPTION
- Container: add solid corrugated top wall (72% opacity) and ghost
  glass front/left walls (18% opacity) so all 6 faces are rendered;
  container now looks closed and realistic while interior stays visible
- Container: auto-reframe camera to fit any container size on changeSize
- Container: add door-seam line detail on back wall; tighten structural
  frame proportions (posts/rails)
- Box colors: apply assigned color directly as material `color` instead
  of a faint emissive tint; cardboard texture switched to near-white
  base so each box type renders with vivid, fully-saturated color
- Box edges: changed to semi-transparent black lines for sharp contrast
  against any box color
- Color palette: replaced Tableau-10 mix with 20 perceptually-distinct,
  high-saturation colors (red, green, blue, orange, purple, teal, …)
- Container presets: updated to real ISO shipping-container interior
  dimensions (20ft 589×239×235 cm, 40ft 1202×239×235 cm, 40ft HC
  1202×269×235 cm); default inputs now match a 20ft container
- Packing animation: auto-starts playback after solve completes so the
  step-by-step loading process is immediately visible

https://claude.ai/code/session_01EanfYkyqqyfToEtvXsxkgU