### PR TITLE
Improve box placement by trying multiple candidate spaces

### DIFF
--- a/js/solvers/GuillotineSolver.js
+++ b/js/solvers/GuillotineSolver.js
@@ -33,39 +33,48 @@ export class GuillotineSolver extends BaseSolver {
         const unPackable = [];
 
         for (const box of sortedBoxes) {
-            let bestScore = Infinity, bestSpaceIdx = -1, bestOrientation = -1;
             const validOrientations = box.getValidOrientations();
 
+            // Collect all (space, orientation) pairs that geometrically fit,
+            // sorted by Best Short Side Fit score so the preferred space is tried
+            // first.  If that space fails physical checks (gravity + support +
+            // collision), we fall through to the next candidate instead of
+            // immediately marking the box as unpackable.
+            const fitCandidates = [];
             for (let si = 0; si < freeSpaces.length; si++) {
                 const sp = freeSpaces[si];
                 for (const ori of validOrientations) {
                     box.orientation = ori;
                     const { x: bw, y: bh, z: bd } = box.size;
                     if (bw <= sp.w + TOL && bh <= sp.h + TOL && bd <= sp.d + TOL) {
-                        // Best Short Side Fit
                         const score = Math.min(sp.w - bw, sp.d - bd);
-                        if (score < bestScore) {
-                            bestScore = score;
-                            bestSpaceIdx = si;
-                            bestOrientation = ori;
-                        }
+                        fitCandidates.push({ si, ori, score });
                     }
                 }
             }
+            fitCandidates.sort((a, b) => a.score - b.score);
 
-            if (bestSpaceIdx === -1) { unPackable.push(box); continue; }
+            if (fitCandidates.length === 0) { unPackable.push(box); continue; }
 
-            const sp = freeSpaces[bestSpaceIdx];
-            box.orientation = bestOrientation;
-            box.position = new Vector3D(sp.x, sp.y, sp.z);
-            gravityDrop(box, container);
+            let placedSi = -1;
+            for (const { si, ori } of fitCandidates) {
+                const sp = freeSpaces[si];
+                box.orientation = ori;
+                box.position = new Vector3D(sp.x, sp.y, sp.z);
+                gravityDrop(box, container);
+                if (!isSufficientlySupported(box, container)) continue;
+                if (!container.canHold(box)) continue;
+                placedSi = si;
+                break;
+            }
 
-            if (!isSufficientlySupported(box, container)) { unPackable.push(box); continue; }
-            if (!container.canHold(box)) { unPackable.push(box); continue; }
+            if (placedSi === -1) { unPackable.push(box); continue; }
+
             container.put(box);
 
+            const sp = freeSpaces[placedSi];
             const { x: bw, y: bh, z: bd } = box.size;
-            freeSpaces.splice(bestSpaceIdx, 1);
+            freeSpaces.splice(placedSi, 1);
 
             // Generate 3 new sub-spaces
             if (sp.w - bw > TOL) freeSpaces.push({ x: sp.x + bw, y: sp.y, z: sp.z, w: sp.w - bw, h: sp.h, d: sp.d });

--- a/js/solvers/HeuristicSolver.js
+++ b/js/solvers/HeuristicSolver.js
@@ -125,9 +125,22 @@ export class HeuristicSolver extends BaseSolver {
                         yLimit += box.size.y;
                         xLimit  = box.size.x;
                     } else if (yLimit < this.container.size.y) {
-                        xLimit = this.container.size.x;
-                        yLimit = this.container.size.y;
-                        unPacked.push(box);
+                        // The preferred new-layer origin is blocked (e.g. another
+                        // box sits at (0, yLimit, 0)).  Before abandoning the box,
+                        // scan all existing candidate positions without the yLimit
+                        // constraint — this catches spaces on top of already-placed
+                        // boxes that the constrained loop above could not see.
+                        for (let i = 0; i < candidates.length; i++) {
+                            const c = candidates[i];
+                            box.position = new Vector3D(c.x, c.y, c.z);
+                            placed = this._orientBoxToFit(box);
+                            if (placed) break;
+                        }
+                        if (!placed) {
+                            xLimit = this.container.size.x;
+                            yLimit = this.container.size.y;
+                            unPacked.push(box);
+                        }
                     }
                 } else {
                     for (posIdx = 0; posIdx < candidates.length; posIdx++) {

--- a/js/solvers/MaximalSpacesSolver.js
+++ b/js/solvers/MaximalSpacesSolver.js
@@ -96,9 +96,13 @@ export class MaximalSpacesSolver extends BaseSolver {
         const unPackable = [];
 
         for (const box of sortedBoxes) {
-            let bestVol = Infinity, bestSpaceIdx = -1, bestOrientation = -1;
             const validOrientations = box.getValidOrientations();
 
+            // Collect all (space, orientation) pairs that geometrically fit,
+            // sorted by space volume ascending (smallest-fit-first heuristic).
+            // If the top candidate fails physical checks (gravity + support +
+            // collision) we try the next one rather than immediately giving up.
+            const fitCandidates = [];
             for (let si = 0; si < freeSpaces.length; si++) {
                 const sp = freeSpaces[si];
                 for (const ori of validOrientations) {
@@ -106,26 +110,30 @@ export class MaximalSpacesSolver extends BaseSolver {
                     const { x: bw, y: bh, z: bd } = box.size;
                     if (bw <= sp.w + TOL && bh <= sp.h + TOL && bd <= sp.d + TOL) {
                         const spVol = sp.w * sp.h * sp.d;
-                        if (spVol < bestVol) {
-                            bestVol = spVol; bestSpaceIdx = si; bestOrientation = ori;
-                        }
+                        fitCandidates.push({ si, ori, spVol });
                     }
                 }
             }
+            fitCandidates.sort((a, b) => a.spVol - b.spVol);
 
-            if (bestSpaceIdx === -1) { unPackable.push(box); continue; }
+            if (fitCandidates.length === 0) { unPackable.push(box); continue; }
 
-            const sp = freeSpaces[bestSpaceIdx];
-            box.orientation = bestOrientation;
-            box.position    = new Vector3D(sp.x, sp.y, sp.z);
-            gravityDrop(box, container);
-            // Gravity drop must not lift the box above the selected space's floor.
-            // A box sitting on top of sp (y ≥ sp.y) would otherwise push the new box
-            // above the container ceiling, causing canHold to fail spuriously.
-            if (box.position.y > sp.y) box.position.y = sp.y;
+            let placedSi = -1;
+            for (const { si, ori } of fitCandidates) {
+                const sp = freeSpaces[si];
+                box.orientation = ori;
+                box.position    = new Vector3D(sp.x, sp.y, sp.z);
+                gravityDrop(box, container);
+                // Gravity drop must not lift the box above the selected space's floor.
+                if (box.position.y > sp.y) box.position.y = sp.y;
+                if (!isSufficientlySupported(box, container)) continue;
+                if (!container.canHold(box)) continue;
+                placedSi = si;
+                break;
+            }
 
-            if (!isSufficientlySupported(box, container)) { unPackable.push(box); continue; }
-            if (!container.canHold(box)) { unPackable.push(box); continue; }
+            if (placedSi === -1) { unPackable.push(box); continue; }
+
             container.put(box);
 
             const newSpaces = [];
@@ -173,9 +181,9 @@ export class MaximalSpacesSolver extends BaseSolver {
         const unPackable = [];
 
         for (const box of sortedBoxes) {
-            let bestVol = Infinity, bestSpaceIdx = -1, bestOrientation = -1;
             const validOrientations = box.getValidOrientations();
 
+            const fitCandidates = [];
             for (let si = 0; si < freeSpaces.length; si++) {
                 const sp = freeSpaces[si];
                 for (const ori of validOrientations) {
@@ -183,23 +191,29 @@ export class MaximalSpacesSolver extends BaseSolver {
                     const { x: bw, y: bh, z: bd } = box.size;
                     if (bw <= sp.w + TOL && bh <= sp.h + TOL && bd <= sp.d + TOL) {
                         const spVol = sp.w * sp.h * sp.d;
-                        if (spVol < bestVol) {
-                            bestVol = spVol; bestSpaceIdx = si; bestOrientation = ori;
-                        }
+                        fitCandidates.push({ si, ori, spVol });
                     }
                 }
             }
+            fitCandidates.sort((a, b) => a.spVol - b.spVol);
 
-            if (bestSpaceIdx === -1) { unPackable.push(box); continue; }
+            if (fitCandidates.length === 0) { unPackable.push(box); continue; }
 
-            const sp = freeSpaces[bestSpaceIdx];
-            box.orientation = bestOrientation;
-            box.position    = new Vector3D(sp.x, sp.y, sp.z);
-            gravityDrop(box, container);
-            if (box.position.y > sp.y) box.position.y = sp.y;
+            let placedSi = -1;
+            for (const { si, ori } of fitCandidates) {
+                const sp = freeSpaces[si];
+                box.orientation = ori;
+                box.position    = new Vector3D(sp.x, sp.y, sp.z);
+                gravityDrop(box, container);
+                if (box.position.y > sp.y) box.position.y = sp.y;
+                if (!isSufficientlySupported(box, container)) continue;
+                if (!container.canHold(box)) continue;
+                placedSi = si;
+                break;
+            }
 
-            if (!isSufficientlySupported(box, container)) { unPackable.push(box); continue; }
-            if (!container.canHold(box)) { unPackable.push(box); continue; }
+            if (placedSi === -1) { unPackable.push(box); continue; }
+
             container.put(box);
 
             const newSpaces = [];


### PR DESCRIPTION
## Summary
Refactored box placement logic across three solver classes to collect and try multiple geometrically-fitting spaces before marking a box as unpackable. This improves packing efficiency by allowing fallback placement options when the preferred space fails physical validation checks (gravity, support, collision).

## Key Changes

**MaximalSpacesSolver & GuillotineSolver:**
- Changed from selecting a single "best" space upfront to collecting all geometrically-fitting (space, orientation) candidates
- Candidates are sorted by their respective heuristics (volume for MaximalSpaces, Best Short Side Fit score for Guillotine)
- Iterate through sorted candidates, attempting placement with gravity drop and physical validation checks
- Only mark box as unpackable if all candidates fail, rather than failing on the first preferred space
- This allows boxes to be placed in secondary spaces when the optimal space is blocked by gravity or support constraints

**HeuristicSolver:**
- Added fallback logic when the preferred new-layer origin is blocked
- Before abandoning a box, scan all existing candidate positions without the yLimit constraint
- This catches spaces on top of already-placed boxes that the constrained loop could not reach
- Only mark box as unpackable if no valid position exists across all candidates

## Implementation Details
- Candidates are collected in arrays with their scoring metrics (spVol, score, etc.)
- Arrays are sorted once before attempting placement, avoiding repeated comparisons
- Early exit via `break` when a valid placement is found
- Maintains the same space subdivision and container update logic as before

https://claude.ai/code/session_01W56vu3YrZnmWZ13sGJuWRV